### PR TITLE
Adds arePositionsInRange as a helper function for BlockPosUtils.

### DIFF
--- a/src/main/java/com/mowmaster/mowlib/MowLibUtils/MowLibBlockPosUtils.java
+++ b/src/main/java/com/mowmaster/mowlib/MowLibUtils/MowLibBlockPosUtils.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class MowLibBlockPosUtils {
     // Returns true if `posOne` and `posTwo` are at most `range` blocks apart.
-    public boolean arePositionsInRange(BlockPos posOne, BlockPos posTwo, int range) {
+    public static boolean arePositionsInRange(BlockPos posOne, BlockPos posTwo, int range) {
         BlockPos distanceVector = posOne.subtract(posTwo);
         return Math.abs(distanceVector.getX()) <= range &&
             Math.abs(distanceVector.getY()) <= range &&

--- a/src/main/java/com/mowmaster/mowlib/MowLibUtils/MowLibBlockPosUtils.java
+++ b/src/main/java/com/mowmaster/mowlib/MowLibUtils/MowLibBlockPosUtils.java
@@ -7,14 +7,20 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
-import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class MowLibBlockPosUtils
-{
+public class MowLibBlockPosUtils {
+    // Returns true if `posOne` and `posTwo` are at most `range` blocks apart.
+    public boolean arePositionsInRange(BlockPos posOne, BlockPos posTwo, int range) {
+        BlockPos distanceVector = posOne.subtract(posTwo);
+        return Math.abs(distanceVector.getX()) <= range &&
+            Math.abs(distanceVector.getY()) <= range &&
+            Math.abs(distanceVector.getZ()) <= range;
+    }
+
     public BlockPos getPosOfBlockBelow(Level level, BlockPos posOfPedestal, int numBelow)
     {
         BlockState state = level.getBlockState(posOfPedestal);


### PR DESCRIPTION
Pull this useful helper up from Pedestals.

I realize as part of this that the range of pedestals was actually shrunk by 1 block during my initial refactoring (as I didn't flip the `>` to a `<=` as part of the negation distribution over the boolean expression that was used). I'll make the appropriate PR for Pedestals to fix the pedestals range + rendering, and this function can be used in all places that range checks are made in the future.